### PR TITLE
Implicit casting of collated expressions

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -445,6 +445,18 @@
     ],
     "sqlState" : "42704"
   },
+  "COLLATION_COULD_NOT_BE_DETERMINED" : {
+    "message" : [
+      "Could not determine which collation to use for string comparison. Use COLLATE function to set the collation explicitly."
+    ],
+    "sqlState" : "22018"
+  },
+  "COLLATION_MISMATCH" : {
+    "message" : [
+      "Collation mismatch between explicit collations \"<left>\" and \"<right>\""
+    ],
+    "sqlState" : "22018"
+  },
   "COLLECTION_SIZE_LIMIT_EXCEEDED" : {
     "message" : [
       "Can't create array with <numberOfElements> elements which exceeding the array size limit <maxRoundedArrayLength>,"

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -29,6 +29,12 @@ import org.apache.spark.sql.catalyst.util.CollatorFactory
 class StringType private(val collationId: Int) extends AtomicType with Serializable {
   def isDefaultCollation: Boolean = collationId == StringType.DEFAULT_COLLATION_ID
 
+  /**
+   * Returns whether the collation is indeterminate. An indeterminate collation is
+   * a result of combination of conflicting non-default implicit collations.
+   */
+  def isIndeterminateCollation: Boolean = collationId == StringType.INDETERMINATE_COLLATION_ID
+
   override def toString: String =
     if (this.isDefaultCollation) "String"
     else s"String(${CollatorFactory.getInfoForId(collationId).collationName})"
@@ -56,5 +62,6 @@ class StringType private(val collationId: Int) extends AtomicType with Serializa
 case object StringType extends StringType(0) {
   // TODO: When we implement session level collation it should be used here as the default.
   val DEFAULT_COLLATION_ID = 0
+  val INDETERMINATE_COLLATION_ID: Int = -1
   def apply(collationId: Int): StringType = new StringType(collationId)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala
@@ -89,6 +89,7 @@ object AnsiTypeCoercion extends TypeCoercionBase {
       StackCoercion ::
       Division ::
       IntegralDivision ::
+      CollationTypeCasts ::
       ImplicitTypeCasts ::
       DateTimeOperations ::
       WindowFrameCoercion ::
@@ -138,15 +139,15 @@ object AnsiTypeCoercion extends TypeCoercionBase {
   @scala.annotation.tailrec
   private def findWiderTypeForString(dt1: DataType, dt2: DataType): Option[DataType] = {
     (dt1, dt2) match {
-      case (StringType, _: IntegralType) => Some(LongType)
-      case (StringType, _: FractionalType) => Some(DoubleType)
-      case (StringType, NullType) => Some(StringType)
+      case (_: StringType, _: IntegralType) => Some(LongType)
+      case (_: StringType, _: FractionalType) => Some(DoubleType)
+      case (st: StringType, NullType) => Some(st)
       // If a binary operation contains interval type and string, we can't decide which
       // interval type the string should be promoted as. There are many possible interval
       // types, such as year interval, month interval, day interval, hour interval, etc.
-      case (StringType, _: AnsiIntervalType) => None
-      case (StringType, a: AtomicType) => Some(a)
-      case (other, StringType) if other != StringType => findWiderTypeForString(StringType, other)
+      case (_: StringType, _: AnsiIntervalType) => None
+      case (_: StringType, a: AtomicType) => Some(a)
+      case (other, st: StringType) if other != StringType => findWiderTypeForString(st, other)
       case _ => None
     }
   }
@@ -188,21 +189,21 @@ object AnsiTypeCoercion extends TypeCoercionBase {
 
       // This type coercion system will allow implicit converting String type as other
       // primitive types, in case of breaking too many existing Spark SQL queries.
-      case (StringType, a: AtomicType) =>
+      case (_: StringType, a: AtomicType) =>
         Some(a)
 
       // If the target type is any Numeric type, convert the String type as Double type.
-      case (StringType, NumericType) =>
+      case (_: StringType, NumericType) =>
         Some(DoubleType)
 
       // If the target type is any Decimal type, convert the String type as the default
       // Decimal type.
-      case (StringType, DecimalType) =>
+      case (_: StringType, DecimalType) =>
         Some(DecimalType.SYSTEM_DEFAULT)
 
       // If the target type is any timestamp type, convert the String type as the default
       // Timestamp type.
-      case (StringType, AnyTimestampType) =>
+      case (_: StringType, AnyTimestampType) =>
         Some(AnyTimestampType.defaultConcreteType)
 
       case (DateType, AnyTimestampType) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -95,22 +95,22 @@ object Cast extends QueryErrorsBase {
     case (NullType, _) => true
 
     case (_, _: StringType) => true
-    case (StringType, _: BinaryType) => true
+    case (_: StringType, _: BinaryType) => true
 
-    case (StringType, BooleanType) => true
+    case (_: StringType, BooleanType) => true
     case (_: NumericType, BooleanType) => true
 
-    case (StringType, TimestampType) => true
+    case (_: StringType, TimestampType) => true
     case (DateType, TimestampType) => true
     case (TimestampNTZType, TimestampType) => true
     case (_: NumericType, TimestampType) => true
 
-    case (StringType, TimestampNTZType) => true
+    case (_: StringType, TimestampNTZType) => true
     case (DateType, TimestampNTZType) => true
     case (TimestampType, TimestampNTZType) => true
 
-    case (StringType, _: CalendarIntervalType) => true
-    case (StringType, _: AnsiIntervalType) => true
+    case (_: StringType, _: CalendarIntervalType) => true
+    case (_: StringType, _: AnsiIntervalType) => true
 
     case (_: AnsiIntervalType, _: IntegralType | _: DecimalType) => true
     case (_: IntegralType | _: DecimalType, _: AnsiIntervalType) => true
@@ -118,12 +118,12 @@ object Cast extends QueryErrorsBase {
     case (_: DayTimeIntervalType, _: DayTimeIntervalType) => true
     case (_: YearMonthIntervalType, _: YearMonthIntervalType) => true
 
-    case (StringType, DateType) => true
+    case (_: StringType, DateType) => true
     case (TimestampType, DateType) => true
     case (TimestampNTZType, DateType) => true
 
     case (_: NumericType, _: NumericType) => true
-    case (StringType, _: NumericType) => true
+    case (_: StringType, _: NumericType) => true
     case (BooleanType, _: NumericType) => true
     case (TimestampType, _: NumericType) => true
 
@@ -192,33 +192,33 @@ object Cast extends QueryErrorsBase {
 
     case (NullType, _) => true
 
-    case (_, StringType) => true
+    case (_, _: StringType) => true
 
-    case (StringType, BinaryType) => true
+    case (_: StringType, BinaryType) => true
     case (_: IntegralType, BinaryType) => true
 
-    case (StringType, BooleanType) => true
+    case (_: StringType, BooleanType) => true
     case (DateType, BooleanType) => true
     case (TimestampType, BooleanType) => true
     case (_: NumericType, BooleanType) => true
 
-    case (StringType, TimestampType) => true
+    case (_: StringType, TimestampType) => true
     case (BooleanType, TimestampType) => true
     case (DateType, TimestampType) => true
     case (_: NumericType, TimestampType) => true
     case (TimestampNTZType, TimestampType) => true
 
-    case (StringType, TimestampNTZType) => true
+    case (_: StringType, TimestampNTZType) => true
     case (DateType, TimestampNTZType) => true
     case (TimestampType, TimestampNTZType) => true
 
-    case (StringType, DateType) => true
+    case (_: StringType, DateType) => true
     case (TimestampType, DateType) => true
     case (TimestampNTZType, DateType) => true
 
-    case (StringType, CalendarIntervalType) => true
-    case (StringType, _: DayTimeIntervalType) => true
-    case (StringType, _: YearMonthIntervalType) => true
+    case (_: StringType, CalendarIntervalType) => true
+    case (_: StringType, _: DayTimeIntervalType) => true
+    case (_: StringType, _: YearMonthIntervalType) => true
     case (_: IntegralType, DayTimeIntervalType(s, e)) if s == e => true
     case (_: IntegralType, YearMonthIntervalType(s, e)) if s == e => true
 
@@ -227,7 +227,7 @@ object Cast extends QueryErrorsBase {
     case (_: AnsiIntervalType, _: IntegralType | _: DecimalType) => true
     case (_: IntegralType | _: DecimalType, _: AnsiIntervalType) => true
 
-    case (StringType, _: NumericType) => true
+    case (_: StringType, _: NumericType) => true
     case (BooleanType, _: NumericType) => true
     case (DateType, _: NumericType) => true
     case (TimestampType, _: NumericType) => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -2603,7 +2603,8 @@ case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpressio
       TypeCheckResult.TypeCheckSuccess
     } else {
       val dataTypeMismatch = children.zipWithIndex.collectFirst {
-        case (e, idx) if !allowedTypes.exists(_.acceptsType(e.dataType)) =>
+        case (e, idx)
+          if !allowedTypes.exists(dt => dt == e.dataType || dt.acceptsType(e.dataType)) =>
           DataTypeMismatch(
             errorSubClass = "UNEXPECTED_INPUT_TYPE",
             messageParameters = Map(
@@ -2644,7 +2645,7 @@ case class Concat(children: Seq[Expression]) extends ComplexTypeMergingExpressio
         val inputs = children.map(_.eval(input).asInstanceOf[Array[Byte]])
         ByteArray.concat(inputs: _*)
       }
-    case StringType =>
+    case _: StringType =>
       input => {
         val inputs = children.map(_.eval(input).asInstanceOf[UTF8String])
         UTF8String.concat(inputs: _*)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3933,4 +3933,21 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "tableSchema" -> toSQLType(tableSchema),
         "actualSchema" -> toSQLType(actualSchema)))
   }
+
+  def collationMismatchError(left: String, right: String): Throwable = {
+    new AnalysisException(
+      errorClass = "COLLATION_MISMATCH",
+      messageParameters = Map(
+        "left" -> left,
+        "right" -> right
+      )
+    )
+  }
+
+  def collationCouldNotBeDeterminedError(): Throwable = {
+    new AnalysisException(
+      errorClass = "COLLATION_COULD_NOT_BE_DETERMINED",
+      messageParameters = Map.empty
+    )
+  }
 }


### PR DESCRIPTION
Automatic casting and collations resolution as per PGSQL behaviour:

1. Collations set on the metadata level are implicit
2. Collations set using the `COLLATE` expression are explicit
3. When there is a combination of expressions of multiple collations the output will be:
   - if there are explicit collations and all of them are equal then that collation will be the output
   - if there are multiple different explicit collations `COLLATION_MISMATCH` will be thrown
   - if there are no explicit collations and only a single type of non default collation, that one will be used
   - if there are no explicit collations and multiple non-default implicit ones `COLLATION_COULD_NOT_BE_DETERMINED` will be thrown
 
Another thing is that `COLLATION_COULD_NOT_BE_DETERMINED` should only be thrown on comparison operations, and we should be able to combine different implicit collations for certain operations like concat and possible others in the future.
This is why I had to add another predefined collation id named `INDETERMINATE_COLLATION_ID` which means that the result is a combination of conflicting non-default implicit collations. Right now it has an id of -1 so it fails if it ever goes to the `CollatorFactory`.