### PR TITLE
[WIP] String functions v1: contains, startsWith, endsWith.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -898,9 +898,119 @@ object EndsWithExpressionBuilder extends StringBinaryPredicateExpressionBuilderB
 }
 
 case class EndsWith(left: Expression, right: Expression) extends StringPredicate {
-  override def compare(l: UTF8String, r: UTF8String): Boolean = l.endsWith(r)
+  override def inputTypes: Seq[DataType] = {
+    // TODO: properly handle String Types with differing collations
+    val leftIsString = left.dataType.getClass.getName.startsWith(
+      "org.apache.spark.sql.types.StringType")
+    val rightIsString = right.dataType.getClass.getName.startsWith(
+      "org.apache.spark.sql.types.StringType")
+    if (leftIsString && rightIsString) {
+      Seq(left.dataType, right.dataType)
+    } else {
+      Seq(StringType, StringType)
+    }
+  }
+  override def compare(l: UTF8String, r: UTF8String): Boolean = {
+    val lCollationID = left.dataType.asInstanceOf[StringType].collationId
+    val rCollationID = right.dataType.asInstanceOf[StringType].collationId
+    // TODO: ensure that lCollationID and rCollationID are equal (compatible)
+    val collationID = if (lCollationID > rCollationID) lCollationID else rCollationID
+    val collatorInfo = CollatorFactory.getInfoForId(collationID)
+    val collator = collatorInfo.collator
+    collator match {
+      // UTF8String collation
+      case null =>
+        collationID match {
+          // UCS_BASIC
+          case 0 =>
+            l.endsWith(r)
+          // UCS_BASIC_LCASE
+          case 1 =>
+            // scalastyle:off caselocale
+            l.toLowerCase.endsWith(r.toLowerCase)
+          // scalastyle:on caselocale
+          // Other special collations without ICU collator
+          case _ =>
+            val lLen = l.numBytes()
+            val rLen = r.numBytes()
+            lLen >= rLen &&
+              collatorInfo.comparator.compare(l.substring(lLen - rLen, lLen), r) == 0
+        }
+      // String ICU collation
+      case _ =>
+        val lStr: String = l.toString
+        val rStr: String = r.toString
+        lStr.length >= rStr.length &&
+          collator.compare(lStr.substring(lStr.length - rStr.length, lStr.length), rStr) == 0
+    }
+  }
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    defineCodeGen(ctx, ev, (c1, c2) => s"($c1).endsWith($c2)")
+    val lCollationID = left.dataType.asInstanceOf[StringType].collationId
+    val rCollationID = right.dataType.asInstanceOf[StringType].collationId
+    // TODO: ensure that lCollationID and rCollationID are equal (compatible)
+    val collationID = if (lCollationID > rCollationID) lCollationID else rCollationID
+    val collatorFactory = ctx.addReferenceObj("collatorFactory", CollatorFactory.getInstance())
+    val collatorInfo = CollatorFactory.getInfoForId(collationID)
+    val collator = collatorInfo.collator
+    val leftGen = if (left.dataType.sameType(StringType)) {
+      left.genCode(ctx)
+    } else {
+      left.asInstanceOf[Collate].inputString.genCode(ctx)
+    }
+    val rightGen = if (right.dataType.sameType(StringType)) {
+      right.genCode(ctx)
+    } else {
+      right.asInstanceOf[Collate].inputString.genCode(ctx)
+    }
+    collator match {
+      case null =>
+        collationID match {
+          case 0 =>
+            // UCS_BASIC
+            defineCodeGen(ctx, ev, (c1, c2) => s"($c1).endsWith($c2)")
+          case 1 =>
+            // UCS_BASIC_LCASE
+            defineCodeGen(ctx, ev, (c1, c2) => s"($c1.toLowerCase()).endsWith($c2.toLowerCase())")
+          case _ =>
+            // Other special collations without ICU collator
+            val resultCode =
+              s"""
+                 |org.apache.spark.sql.catalyst.util.CollatorFactory.CollatorInfo collatorInfo =
+                 |$collatorFactory.getInfoForId(collID);
+                 |int lLen = ${leftGen.value}.toString().length();
+                 |int rLen = ${rightGen.value}.toString().length();
+                 |result = lLen >= rLen && collatorInfo.comparator.compare(
+                 |    ${leftGen.value}.substring(lLen - rLen, lLen), ${rightGen.value}) == 0;
+                 |""".stripMargin
+            ev.copy(code =
+              code"""
+                    |${leftGen.code}
+                    |${rightGen.code}
+                    |boolean ${ev.isNull} = false;
+                    |$resultCode
+                    |boolean ${ev.value} = result;
+                    |""".stripMargin)
+        }
+      case _ =>
+        val resultCode =
+          s"""
+             |org.apache.spark.sql.catalyst.util.CollatorFactory.CollatorInfo collatorInfo =
+             |$collatorFactory.getInfoForId(${collationID});
+             |com.ibm.icu.text.Collator collator = collatorInfo.collator;
+             |String lStr = ${leftGen.value}.toString();
+             |String rStr = ${rightGen.value}.toString();
+             |boolean result = lStr.length() >= rStr.length() && collator.compare(
+             |  lStr.substring(lStr.length() - rStr.length(), lStr.length()), rStr) == 0;
+             |""".stripMargin
+        ev.copy(code =
+          code"""
+                |${leftGen.code}
+                |${rightGen.code}
+                |boolean ${ev.isNull} = false;
+                |$resultCode
+                |boolean ${ev.value} = result;
+                |""".stripMargin)
+    }
   }
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): EndsWith = copy(left = newLeft, right = newRight)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -322,6 +322,106 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(c1 contains Collate("Ć", "SR_CI_AI"), true, row)
     checkEvaluation(c1 contains Collate("C", "SR_CI_AS"), true, row)
     checkEvaluation(c1 contains Collate("c", "SR_CS_AS"), true, row)
+
+    checkEvaluation(c1 startsWith "a", true, row)
+    checkEvaluation(c1 startsWith Collate("A", "UCS_BASIC"), false, row)
+    checkEvaluation(c1 startsWith Collate("A", "UCS_BASIC_LCASE"), true, row)
+    checkEvaluation(c1 startsWith Collate("A", "UNICODE_CI"), true, row)
+    checkEvaluation(c1 startsWith Collate("Ä", "DE_CI_AI"), true, row)
+    checkEvaluation(c1 startsWith Collate("A", "DE_CI_AS"), true, row)
+    checkEvaluation(c1 startsWith Collate("a", "DE_CS_AS"), true, row)
+  }
+
+  test("Support startsWith string expression with Collation") {
+    // Test 'startsWith' with different collations
+
+    // UCS_BASIC (default)
+    checkEvaluation(StartsWith(Literal(""), Literal("")), true)
+    checkEvaluation(StartsWith(Literal(""), Literal("c")), false)
+    checkEvaluation(StartsWith(Literal("c"), Literal("")), true)
+    checkEvaluation(StartsWith(Literal("c"), Literal("c")), true)
+    checkEvaluation(StartsWith(Literal("cde"), Literal("c")), true)
+    checkEvaluation(StartsWith(Literal("abc"), Literal("c")), false)
+    checkEvaluation(StartsWith(Literal("abde"), Literal("c")), false)
+    checkEvaluation(StartsWith(Literal("abcde"), Literal("c")), false)
+
+    // UCS_BASIC vs. UCS_BASIC_LCASE vs. UNICODE_CI
+    checkEvaluation(StartsWith(Collate("cde", "UCS_BASIC"), Literal("c")), true)
+    checkEvaluation(StartsWith(Collate("cde", "UCS_BASIC"), Literal("C")), false)
+    checkEvaluation(StartsWith(Collate("Cde", "UCS_BASIC"), Literal("c")), false)
+    checkEvaluation(StartsWith(Collate("Cde", "UCS_BASIC"), Literal("C")), true)
+    checkEvaluation(StartsWith(Collate("cde", "UCS_BASIC_LCASE"), Literal("c")), true)
+    checkEvaluation(StartsWith(Collate("cde", "UCS_BASIC_LCASE"), Literal("C")), true)
+    checkEvaluation(StartsWith(Collate("Cde", "UCS_BASIC_LCASE"), Literal("c")), true)
+    checkEvaluation(StartsWith(Collate("Cde", "UCS_BASIC_LCASE"), Literal("C")), true)
+    checkEvaluation(StartsWith(Collate("cde", "UNICODE_CI"), Literal("c")), true)
+    checkEvaluation(StartsWith(Collate("cde", "UNICODE_CI"), Literal("C")), true)
+    checkEvaluation(StartsWith(Collate("Cde", "UNICODE_CI"), Literal("c")), true)
+    checkEvaluation(StartsWith(Collate("Cde", "UNICODE_CI"), Literal("C")), true)
+
+    // Serbian language collation tests (should also work for all the other collators with ID >= 4)
+    val list_left: List[String] = List("cde", "Cde", "ćde", "Ćde")
+    val list_right: List[String] = List("c", "C", "ć", "Ć")
+    var list_result: List[Boolean] = List()
+
+    // SR_CI_AI
+    list_result = List(
+      //  c     C      ć      Ć
+      true, true, true, true, // cde
+      true, true, true, true, // Cde
+      true, true, true, true, // ćde
+      true, true, true, true) // Ćde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(StartsWith(Collate(left, "SR_CI_AI"), Literal(right)), expected_result)
+      checkEvaluation(StartsWith(Literal(left), Collate(right, "SR_CI_AI")), expected_result)
+      checkEvaluation(StartsWith(Collate(left, "SR_CI_AI"), Collate(right, "SR_CI_AI")),
+        expected_result)
+      // codegen off
+      val l: UTF8String = UTF8String.fromString(left)
+      val r: UTF8String = UTF8String.fromString(right)
+      checkEvaluation(StartsWith(Literal(left), Collate(right, "SR_CI_AI")).compare(l, r),
+        expected_result)
+    }
+
+    // SR_CI_AS
+    list_result = List(
+      //  c     C      ć      Ć
+      true, true, false, false, // cde
+      true, true, false, false, // Cde
+      false, false, true, true, // ćde
+      false, false, true, true) // Ćde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(StartsWith(Collate(left, "SR_CI_AS"), Literal(right)), expected_result)
+      checkEvaluation(StartsWith(Literal(left), Collate(right, "SR_CI_AS")), expected_result)
+      checkEvaluation(StartsWith(Collate(left, "SR_CI_AS"), Collate(right, "SR_CI_AS")),
+        expected_result)
+    }
+
+    // SR_CS_AS
+    list_result = List(
+      //  c     C      ć      Ć
+      true, false, false, false, // cde
+      false, true, false, false, // Cde
+      false, false, true, false, // ćde
+      false, false, false, true) // Ćde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(StartsWith(Collate(left, "SR_CS_AS"), Literal(right)), expected_result)
+      checkEvaluation(StartsWith(Literal(left), Collate(right, "SR_CS_AS")), expected_result)
+      checkEvaluation(StartsWith(Collate(left, "SR_CS_AS"), Collate(right, "SR_CS_AS")),
+        expected_result)
+    }
   }
 
   test("Substring") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.math.{BigDecimal => JavaBigDecimal}
-
 import org.apache.spark.{SPARK_DOC_ROOT, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
@@ -28,6 +27,7 @@ import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
@@ -217,6 +217,111 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     GenerateUnsafeProjection.generate(Contains(Literal("\"quote"), Literal("\"quote")) :: Nil)
     GenerateUnsafeProjection.generate(EndsWith(Literal("\"quote"), Literal("\"quote")) :: Nil)
     GenerateUnsafeProjection.generate(StartsWith(Literal("\"quote"), Literal("\"quote")) :: Nil)
+  }
+
+  test("Support contains string expression with Collation") {
+    // Test 'contains' with different collations
+
+    // UCS_BASIC (default)
+    checkEvaluation(Contains(Literal(""), Literal("")), true)
+    checkEvaluation(Contains(Literal(""), Literal("c")), false)
+    checkEvaluation(Contains(Literal("c"), Literal("")), true)
+    checkEvaluation(Contains(Literal("c"), Literal("c")), true)
+    checkEvaluation(Contains(Literal("cde"), Literal("c")), true)
+    checkEvaluation(Contains(Literal("abc"), Literal("c")), true)
+    checkEvaluation(Contains(Literal("abde"), Literal("c")), false)
+    checkEvaluation(Contains(Literal("abcde"), Literal("c")), true)
+
+    // UCS_BASIC vs. UCS_BASIC_LCASE vs. UNICODE_CI
+    checkEvaluation(Contains(Collate("abcde", "UCS_BASIC"), Literal("c")), true)
+    checkEvaluation(Contains(Collate("abcde", "UCS_BASIC"), Literal("C")), false)
+    checkEvaluation(Contains(Collate("abCde", "UCS_BASIC"), Literal("c")), false)
+    checkEvaluation(Contains(Collate("abCde", "UCS_BASIC"), Literal("C")), true)
+    checkEvaluation(Contains(Collate("abcde", "UCS_BASIC_LCASE"), Literal("c")), true)
+    checkEvaluation(Contains(Collate("abcde", "UCS_BASIC_LCASE"), Literal("C")), true)
+    checkEvaluation(Contains(Collate("abCde", "UCS_BASIC_LCASE"), Literal("c")), true)
+    checkEvaluation(Contains(Collate("abCde", "UCS_BASIC_LCASE"), Literal("C")), true)
+    checkEvaluation(Contains(Collate("abcde", "UNICODE_CI"), Literal("c")), true)
+    checkEvaluation(Contains(Collate("abcde", "UNICODE_CI"), Literal("C")), true)
+    checkEvaluation(Contains(Collate("abCde", "UNICODE_CI"), Literal("c")), true)
+    checkEvaluation(Contains(Collate("abCde", "UNICODE_CI"), Literal("C")), true)
+
+    // Serbian language collation tests (should also work for all the other collators with ID >= 4)
+    val list_left: List[String] = List("abcde", "abCde", "abćde", "abĆde")
+    val list_right: List[String] = List("c", "C", "ć", "Ć")
+    var list_result: List[Boolean] = List()
+
+    // SR_CI_AI
+    list_result = List(
+    //  c     C      ć      Ć
+      true, true, true, true, // abcde
+      true, true, true, true, // abCde
+      true, true, true, true, // abćde
+      true, true, true, true) // abĆde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(Contains(Collate(left, "SR_CI_AI"), Literal(right)), expected_result)
+      checkEvaluation(Contains(Literal(left), Collate(right, "SR_CI_AI")), expected_result)
+      checkEvaluation(Contains(Collate(left, "SR_CI_AI"), Collate(right, "SR_CI_AI")),
+        expected_result)
+      // codegen off
+      val l: UTF8String = UTF8String.fromString(left)
+      val r: UTF8String = UTF8String.fromString(right)
+      checkEvaluation(Contains(Literal(left), Collate(right, "SR_CI_AI")).compare(l, r),
+        expected_result)
+    }
+
+    // SR_CI_AS
+    list_result = List(
+    //  c     C      ć      Ć
+      true, true, false, false, // abcde
+      true, true, false, false, // abCde
+      false, false, true, true, // abćde
+      false, false, true, true) // abĆde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(Contains(Collate(left, "SR_CI_AS"), Literal(right)), expected_result)
+      checkEvaluation(Contains(Literal(left), Collate(right, "SR_CI_AS")), expected_result)
+      checkEvaluation(Contains(Collate(left, "SR_CI_AS"), Collate(right, "SR_CI_AS")),
+        expected_result)
+    }
+
+    // SR_CS_AS
+    list_result = List(
+    //  c     C      ć      Ć
+      true, false, false, false, // abcde
+      false, true, false, false, // abCde
+      false, false, true, false, // abćde
+      false, false, false, true) // abĆde
+    for {
+      (left, index_left) <- list_left.zipWithIndex
+      (right, index_right) <- list_right.zipWithIndex
+    } {
+      val expected_result = list_result(index_left * list_right.length + index_right)
+      checkEvaluation(Contains(Collate(left, "SR_CS_AS"), Literal(right)), expected_result)
+      checkEvaluation(Contains(Literal(left), Collate(right, "SR_CS_AS")), expected_result)
+      checkEvaluation(Contains(Collate(left, "SR_CS_AS"), Collate(right, "SR_CS_AS")),
+        expected_result)
+    }
+  }
+
+  test("StringComparison with Collation") {
+    val row = create_row("abc", null)
+    val c1 = $"a".string.at(0)
+
+    checkEvaluation(c1 contains "c", true, row)
+    checkEvaluation(c1 contains Collate("C", "UCS_BASIC"), false, row)
+    checkEvaluation(c1 contains Collate("C", "UCS_BASIC_LCASE"), true, row)
+    checkEvaluation(c1 contains Collate("C", "UNICODE_CI"), true, row)
+    checkEvaluation(c1 contains Collate("Ć", "SR_CI_AI"), true, row)
+    checkEvaluation(c1 contains Collate("C", "SR_CI_AS"), true, row)
+    checkEvaluation(c1 contains Collate("c", "SR_CS_AS"), true, row)
   }
 
   test("Substring") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -792,4 +792,166 @@ class CollationSuite extends QueryTest
     }
   }
 
+  test("Support endsWith string expression with Collation") {
+    // Test 'endsWith' with different collations
+    var listLeft: List[String] = List()
+    var listRight: List[String] = List()
+    var listResult: List[Boolean] = List()
+
+    // UCS_BASIC (default)
+    listLeft = List("", "c", "abc", "cde", "abde", "abcde", "C", "ABC", "CDE", "ABDE", "ABCDE")
+    listRight = List("", "c", "abc", "cde", "abde", "abcde", "C", "ABC", "CDE", "ABDE", "ABCDE")
+    listResult = List(
+    //  ""     c     abc    cde   abde  abcde    C     ABC    CDE    ABDE  ABCDE
+      true, false, false, false, false, false, false, false, false, false, false, //  ""
+      true, true, false, false, false, false, false, false, false, false, false,  //   c
+      true, true, true, false, false, false, false, false, false, false, false,   // abc
+      true, false, false, true, false, false, false, false, false, false, false,  //   cde
+      true, false, false, false, true, false, false, false, false, false, false,  // abde
+      true, false, false, true, false, true, false, false, false, false, false,   // abcde
+      true, false, false, false, false, false, true, false, false, false, false,  //   C
+      true, false, false, false, false, false, true, true, false, false, false,   // ABC
+      true, false, false, false, false, false, false, false, true, false, false,  //   CDE
+      true, false, false, false, false, false, false, false, false, true, false,  // ABDE
+      true, false, false, false, false, false, false, false, true, false, true)   // ABCDE
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      val expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', '" + right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'UCS_BASIC'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UCS_BASIC'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UCS_BASIC'), collate('" +
+        right + "', 'UCS_BASIC'))"), Row(expectedAnswer))
+    }
+
+    // UCS_BASIC_LCASE
+    listResult = List(
+    //  ""     c     abc    cde   abde  abcde    C     ABC    CDE    ABDE  ABCDE
+      true, false, false, false, false, false, false, false, false, false, false, //  ""
+      true, true, false, false, false, false, true, false, false, false, false,   //   c
+      true, true, true, false, false, false, true, true, false, false, false,     // abc
+      true, false, false, true, false, false, false, false, true, false, false,   //   cde
+      true, false, false, false, true, false, false, false, false, true, false,   // abde
+      true, false, false, true, false, true, false, false, true, false, true,     // abcde
+      true, true, false, false, false, false, true, false, false, false, false,   //   C
+      true, true, true, false, false, false, true, true, false, false, false,     // ABC
+      true, false, false, true, false, false, false, false, true, false, false,   //   CDE
+      true, false, false, false, true, false, false, false, false, true, false,   // ABDE
+      true, false, false, true, false, true, false, false, true, false, true)     // ABCDE
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      val expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'UCS_BASIC_LCASE'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UCS_BASIC_LCASE'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UCS_BASIC_LCASE'), collate('" +
+        right + "', 'UCS_BASIC_LCASE'))"), Row(expectedAnswer))
+    }
+
+    // Serbian language collation tests (should also work for all the other collators with ID >= 4)
+    listLeft = List("abc", "abC", "abć", "abĆ")
+    listRight = List("c", "C", "ć", "Ć")
+    val listResultNoCollation = List(
+      //  c     C      ć      Ć
+      true, false, false, false, // abc
+      false, true, false, false, // abC
+      false, false, true, false, // abć
+      false, false, false, true) // abĆ
+
+    // UNICODE_CI
+    listResult = List(
+      //  c     C      ć      Ć
+      true, true, false, false, // abc
+      true, true, false, false, // abC
+      false, false, true, true, // abć
+      false, false, true, true) // abĆ
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      // without collation
+      var expectedAnswer = listResultNoCollation(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', '" + right + "')"),
+        Row(expectedAnswer))
+      // with collation
+      expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'UNICODE_CI'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UNICODE_CI'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'UNICODE_CI'), collate('" +
+        right + "', 'UNICODE_CI'))"), Row(expectedAnswer))
+    }
+
+    // SR_CI_AI
+    listResult = List(
+      //  c     C      ć      Ć
+      true, true, true, true, // abc
+      true, true, true, true, // abC
+      true, true, true, true, // abć
+      true, true, true, true) // abĆ
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      // with collation
+      val expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'SR_CI_AI'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CI_AI'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CI_AI'), collate('" +
+        right + "', 'SR_CI_AI'))"), Row(expectedAnswer))
+    }
+
+    // SR_CI_AS
+    listResult = List(
+      //  c     C      ć      Ć
+      true, true, false, false, // abc
+      true, true, false, false, // abC
+      false, false, true, true, // abć
+      false, false, true, true) // abĆ
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      // with collation
+      val expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'SR_CI_AS'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CI_AS'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CI_AS'), collate('" +
+        right + "', 'SR_CI_AS'))"), Row(expectedAnswer))
+    }
+
+    // SR_CS_AS
+    listResult = List(
+      //  c     C      ć      Ć
+      true, false, false, false, // abc
+      false, true, false, false, // abC
+      false, false, true, false, // abć
+      false, false, false, true) // abĆ
+    for {
+      (left, index_left) <- listLeft.zipWithIndex
+      (right, index_right) <- listRight.zipWithIndex
+    } {
+      // with collation
+      val expectedAnswer = listResult(index_left * listRight.length + index_right)
+      checkAnswer(sql("SELECT endsWith('" + left + "', collate('" +
+        right + "', 'SR_CS_AS'))"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CS_AS'), '" +
+        right + "')"), Row(expectedAnswer))
+      checkAnswer(sql("SELECT endsWith(collate('" + left + "', 'SR_CS_AS'), collate('" +
+        right + "', 'SR_CS_AS'))"), Row(expectedAnswer))
+    }
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor built-in string functions to support collation for: contains, startsWith, endsWith.


### Why are the changes needed?
Add collation support for built-in string functions in Spark.


### Does this PR introduce _any_ user-facing change?
Yes, users should now be able to use COLLATE within arguments for built-in string functions: CONTAINS, STARTSWITH, ENDSWITH in Spark SQL queries.


### How was this patch tested?
Unit tests for:
- string expressions (StringExpressionsSuite)
- queries using "collate" (CollationSuite)


### Was this patch authored or co-authored using generative AI tooling?
Yes.